### PR TITLE
Shape translation and OpenVSP wing trailing edge

### DIFF
--- a/afem/exchange/vsp.py
+++ b/afem/exchange/vsp.py
@@ -659,9 +659,14 @@ def _process_unsplit_wing(compound, divide_closed, reloft, tol):
 
     # Segment off the end caps and the trailing edges.
     u1, u2 = uknots[1], uknots[-2]
-    v1, v2 = vknots[1], vknots[-2]
+    if all(master_surf.eval(u1, 0).xyz == master_surf.eval(u1, 1).xyz):
+        sharp_te = True
+        v_te1, v_te2 = vknots[1], vknots[-2]
+    else:
+        sharp_te = False
+        v_te1, v_te2 = vknots[0], vknots[-1]
     s1 = master_surf.copy()
-    s1.segment(u1, u2, v1, v2)
+    s1.segment(u1, u2, v_te1, v_te2)
 
     # Reloft the surface by tessellating a curve at each spanwise knot. This
     # enforces C1 continuity but assumes linear spanwise wing which may not
@@ -699,22 +704,22 @@ def _process_unsplit_wing(compound, divide_closed, reloft, tol):
 
         # Segment off end caps
         u1, u2 = uknots[0], uknots[1]
-        v1, v2 = vknots[1], vsplit
+        v1, v2 = v_te1, vsplit
         s2 = master_surf.copy()
         s2.segment(u1, u2, v1, v2)
 
         u1, u2 = uknots[0], uknots[1]
-        v1, v2 = vsplit, vknots[-2]
+        v1, v2 = vsplit, v_te2
         s3 = master_surf.copy()
         s3.segment(u1, u2, v1, v2)
 
         u1, u2 = uknots[-2], uknots[-1]
-        v1, v2 = vknots[1], vsplit
+        v1, v2 = v_te1, vsplit
         s4 = master_surf.copy()
         s4.segment(u1, u2, v1, v2)
 
         u1, u2 = uknots[-2], uknots[-1]
-        v1, v2 = vsplit, vknots[-2]
+        v1, v2 = vsplit, v_te2
         s5 = master_surf.copy()
         s5.segment(u1, u2, v1, v2)
 

--- a/afem/topology/transform.py
+++ b/afem/topology/transform.py
@@ -18,6 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 from OCCT.BRepBuilderAPI import BRepBuilderAPI_Transform
 from OCCT.gce import gce_MakeMirror
+from OCCT.gce import gce_MakeTranslation
 
 from afem.topology.entities import Shape
 
@@ -35,6 +36,25 @@ def mirror_shape(shape, pln):
     :raise RuntimeError: If the transformation fails or is not done.
     """
     trsf = gce_MakeMirror(pln.gp_pln).Value()
+    builder = BRepBuilderAPI_Transform(shape.object, trsf, True)
+    if not builder.IsDone():
+        raise RuntimeError('Failed to mirror the shape.')
+    return Shape.wrap(builder.Shape())
+
+
+def translate_shape(shape, vec):
+    """
+    Translate a shape along a vector.
+
+    :param afem.topology.entities.Shape shape: The shape.
+    :param Union[afem.geometry.entitites.Vector, Sequence] vec: The vector.
+
+    :return: The translated shape.
+    :rtype: afem.topology.entities.Shape
+
+    :raise RuntimeError: If the translation fails or is not done.
+    """
+    trsf = gce_MakeTranslation(vec.gp_vec).Value()
     builder = BRepBuilderAPI_Transform(shape.object, trsf, True)
     if not builder.IsDone():
         raise RuntimeError('Failed to mirror the shape.')


### PR DESCRIPTION
Created a wrapper for translating shapes and a capability for processing OpenVSP wings with thick trailing edges.

## Description
Copied the mirror_shape wrapped function for OCCT and used the gce_MakeTranslation class to translate shapes. Also evaluate chordwise knots at the trailing edge and if they are not at the same location, then the last set of knots along the span of the wing is not trimmed off.

## Motivation and Context
Needed to copy wings and use this rebuild function, but the original function assumed a sharp trailing edge.

## How Has This Been Tested?
This was tested in the Rapid Airframe Design Environment with both PEGASUS and CRM OpenVSP files with thick trailing edges, but not added directly to afem tests. The OpenVSP file must use the TE Closure option rather than the TE trim option to achieve a blunt trailing edge.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
